### PR TITLE
Make unit tests use Docker container `influxdb:latest`

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -65,7 +65,13 @@ jobs:
       - name: Build
         working-directory: build
         run: cmake --build . --config ${{ matrix.config.build_type }} --parallel 2
-      
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/bin/*
+
       - name: Pull Influx image
         working-directory: build
         run: docker pull influxdb:latest

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -71,6 +71,7 @@ jobs:
         with:
           name: build
           path: build/bin/*
+          retention-days: 5
 
       - name: Pull Influx image
         working-directory: build

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -42,17 +42,6 @@ jobs:
       - name: Create directories
         run: mkdir build
 
-      - name: Install InfluxDB (Ubuntu)
-        if: matrix.config.os == 'ubuntu-20.04'
-        uses: ngc7293/influxdb-action@5413da1dc6e2c7c06ff22fd5c016bafaed1445dc
-        with:
-          influxdb_version: latest
-          influxdb_org: influx-cpp-test
-          influxdb_user: influx-cpp-test
-          influxdb_password: DummyPassword0
-          influxdb_bucket: dummy
-          influxdb_token: dummy
-
       - name: Install Third Parties (Ubuntu)
         if: matrix.config.os == 'ubuntu-20.04'
         working-directory: build
@@ -76,20 +65,11 @@ jobs:
       - name: Build
         working-directory: build
         run: cmake --build . --config ${{ matrix.config.build_type }} --parallel 2
-
-      - name: Test without API
-        if: matrix.config.os == 'windows-2022'
+      
+      - name: Pull Influx image
         working-directory: build
-        run: bin/influx.test --gtest_filter='-InfluxTest*:BucketTest*'  # These tests require a functional Influx
-
-      - name: Setup tests with API
-        if: matrix.config.os == 'ubuntu-20.04'
-        working-directory: build
-        run: |
-          export INFLUX_ORG_ID=$(influx bucket delete -n dummy -o influx-cpp-test -t dummy --json | jq -r .orgID)
-          echo "{\"host\": \"http://localhost:8086\", \"org\": \"${INFLUX_ORG_ID}\", \"token\": \"dummy\"}" > test.config.json
+        run: docker pull influxdb:latest
 
       - name: Test with API
-        if: matrix.config.os == 'ubuntu-20.04'
         working-directory: build
-        run: bin/influx.test
+        run: bin/influx.test --use-container

--- a/include/influx/client.hh
+++ b/include/influx/client.hh
@@ -15,7 +15,7 @@ enum class Verb {
     GET,
     POST,
     PUT,
-    ELETE
+    DELETE
 };
 
 struct HttpResponse {

--- a/include/influx/client.hh
+++ b/include/influx/client.hh
@@ -15,7 +15,7 @@ enum class Verb {
     GET,
     POST,
     PUT,
-    DELETE
+    REMOVE // HACK: MSVC won't allow DELETE as a enum value, causes errors
 };
 
 struct HttpResponse {

--- a/include/influx/influx.hh
+++ b/include/influx/influx.hh
@@ -33,6 +33,9 @@ public:
 
     Bucket operator[](const std::string& name);
 
+    bool Ready();
+    std::string OrgIdFromName(const std::string& name);
+
 private:
     struct Priv;
     std::unique_ptr<Priv> d_;

--- a/src/client.cc
+++ b/src/client.cc
@@ -51,10 +51,12 @@ struct HttpClient::Priv {
     {
         std::string out;
 
-        if (endpoint.find("?") == std::string::npos) {
-            out = "?orgID=";
-        } else {
-            out = "&orgID=";
+        if (endpoint.find("orgID=") == std::string::npos && endpoint.find("org=") == std::string::npos) {
+            if (endpoint.find("?") == std::string::npos) {
+                out = "?orgID=";
+            } else {
+                out = "&orgID=";
+            }
         }
 
         return host + endpoint + out + org;
@@ -110,7 +112,7 @@ HttpResponse HttpClient::Delete(
     const std::vector<std::pair<std::string, std::string>> headers
 )
 {
-    return Perform(Verb::ELETE, endpoint, body, headers);
+    return Perform(Verb::DELETE, endpoint, body, headers);
 }
 
 HttpResponse HttpClient::Perform(
@@ -133,7 +135,7 @@ HttpResponse HttpClient::Perform(
             curl_easy_setopt(d_->handle, CURLOPT_POST, 1);
             curl_easy_setopt(d_->handle, CURLOPT_POSTFIELDSIZE, source.body.length());
             break;
-        case Verb::ELETE:
+        case Verb::DELETE:
             curl_easy_setopt(d_->handle, CURLOPT_CUSTOMREQUEST, "DELETE");
             curl_easy_setopt(d_->handle, CURLOPT_POSTFIELDSIZE, source.body.length());
             break;

--- a/src/client.cc
+++ b/src/client.cc
@@ -112,7 +112,7 @@ HttpResponse HttpClient::Delete(
     const std::vector<std::pair<std::string, std::string>> headers
 )
 {
-    return Perform(Verb::DELETE, endpoint, body, headers);
+    return Perform(Verb::REMOVE, endpoint, body, headers);
 }
 
 HttpResponse HttpClient::Perform(
@@ -135,7 +135,7 @@ HttpResponse HttpClient::Perform(
             curl_easy_setopt(d_->handle, CURLOPT_POST, 1);
             curl_easy_setopt(d_->handle, CURLOPT_POSTFIELDSIZE, source.body.length());
             break;
-        case Verb::DELETE:
+        case Verb::REMOVE:
             curl_easy_setopt(d_->handle, CURLOPT_CUSTOMREQUEST, "DELETE");
             curl_easy_setopt(d_->handle, CURLOPT_POSTFIELDSIZE, source.body.length());
             break;

--- a/src/influx.cc
+++ b/src/influx.cc
@@ -179,4 +179,22 @@ Bucket Influx::operator[](const std::string& name)
     return GetBucketByName(name);
 }
 
+bool Influx::Ready()
+{
+    try {
+        auto response = d_->client.Get("/ready");
+        auto data = nlohmann::json::parse(response.body);
+        return (data["status"] == "ready");
+    } catch (...) {
+        return false;
+    }
+}
+
+std::string Influx::OrgIdFromName(const std::string& name)
+{
+    auto response = d_->client.Get("/api/v2/orgs/?org=" + name);
+    auto data = nlohmann::json::parse(response.body);
+    return data["orgs"][0]["id"].get<std::string>();
+}
+
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,4 +7,10 @@ add_executable(influx.test
     test_measurement.cc
 )
 
-target_link_libraries(influx.test PRIVATE CONAN_PKG::gtest CONAN_PKG::nlohmann_json influx)
+target_link_libraries(influx.test
+    PRIVATE
+        CONAN_PKG::gtest
+        CONAN_PKG::libcurl
+        CONAN_PKG::nlohmann_json
+        influx
+)

--- a/tests/config.hh
+++ b/tests/config.hh
@@ -11,32 +11,33 @@ using namespace std::chrono_literals;
 
 namespace influx::test {
 
+extern nlohmann::json docker_config;
+
 inline const nlohmann::json config()
 {
-    std::ifstream ifs;
-    nlohmann::json c;
-    
-    if (!std::filesystem::exists("test.config.json")) {
-        std::cerr << "Could not find 'test.config.json' in " << std::filesystem::current_path() << std::endl;
-        exit(-1);
+    if (std::filesystem::exists("test.config.json")) {
+        nlohmann::json c;
+        std::ifstream ifs;
+        ifs.open("test.config.json");
+        ifs >> c;
+
+        if (!c.count("host") && !c["host"].is_string()) {
+            std::cerr << "Invalid test config: missing 'host' field" << std::endl;
+        }
+
+        if (!c.count("org") && !c["org"].is_string()) {
+            std::cerr << "Invalid test config: missing 'org' field" << std::endl;
+        }
+
+        if (!c.count("token") && !c["token"].is_string()) {
+            std::cerr << "Invalid test config: missing 'token' field" << std::endl;
+        }
+        return c;
+    } else {
+        return docker_config;
     }
 
-    ifs.open("test.config.json");
-    ifs >> c;
 
-    if (!c.count("host") && !c["host"].is_string()) {
-        std::cerr << "Invalid test config: missing 'host' field" << std::endl;
-    }
-
-    if (!c.count("org") && !c["org"].is_string()) {
-        std::cerr << "Invalid test config: missing 'org' field" << std::endl;
-    }
-
-    if (!c.count("token") && !c["token"].is_string()) {
-        std::cerr << "Invalid test config: missing 'token' field" << std::endl;
-    }
-
-    return c;
 }
 
 inline influx::Influx db()

--- a/tests/docker.hh
+++ b/tests/docker.hh
@@ -5,7 +5,9 @@
 #include <string>
 #include <vector>
 
+#define NOMINMAX
 #include <curl/curl.h>
+#undef NOMINMAX
 
 #include <nlohmann/json.hpp>
 
@@ -86,7 +88,7 @@ public:
 
     Response Delete(const std::string& endpoint, const nlohmann::json& body = {})
     {
-        auto [code, content] = CurlRequest(Verb::DELETE, endpoint, body.dump());
+        auto [code, content] = CurlRequest(Verb::DEL, endpoint, body.dump());
         return {code, content.empty() ? nlohmann::json::object() : nlohmann::json::parse(content)};
     }
 
@@ -96,7 +98,7 @@ public:
     }
 
 private:
-    enum class Verb { GET, POST, DELETE };
+    enum class Verb { GET, POST, DEL };
 
     std::pair<int, std::string> CurlRequest(Verb verb, const std::string& endpoint, const std::string& body = "")
     {
@@ -115,7 +117,7 @@ private:
             curl_easy_setopt(curl_, CURLOPT_POST, 1);
             curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, source.body.length());
             verbStr = "POST";
-        } else if (verb == Verb::DELETE) {
+        } else if (verb == Verb::DEL) {
             curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "DELETE");
             curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, source.body.length());
             verbStr = "DELETE";

--- a/tests/docker.hh
+++ b/tests/docker.hh
@@ -1,0 +1,171 @@
+#ifndef DOCKER_HH_
+#define DOCKER_HH_
+
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <curl/curl.h>
+
+#include <nlohmann/json.hpp>
+
+namespace docker {
+
+enum class Protocol { TCP, UDP };
+
+struct Port {
+    Protocol protocol;
+    std::uint16_t port;
+};
+
+struct Response {
+    int code;
+    nlohmann::json content;
+};
+
+class Docker {
+public:
+    Docker()
+        : curl_(curl_easy_init())
+    {
+    }
+
+    ~Docker()
+    {
+        curl_easy_cleanup(curl_);
+    }
+
+    std::optional<std::string> Launch(const std::string& image, const std::vector<Port>& exposedPorts, const std::unordered_map<std::string, std::string>& env)
+    {
+        nlohmann::json body = {
+            {"Image", image},
+        };
+
+        for (const Port& port: exposedPorts) {
+            std::string id = std::to_string(port.port) + std::string(port.protocol == Protocol::TCP ? "/tcp" : "/udp");
+            body["ExposedPorts"][id] = nlohmann::json::object();
+        }
+
+        for (const auto& var: env) {
+            body["Env"].push_back(var.first + "=" + var.second);
+        }
+
+        auto [code, content] = Post("/containers/create", body);
+        if (code == 201 && content.count("Id")) {
+
+            auto id = content["Id"].get<std::string>();
+            if (Post("/containers/" + id + "/start").code == 204) {
+                return id;
+            }
+        }
+
+        return {};
+    }
+
+    void Stop(const std::string& id)
+    {
+        Post("/containers/" + id + "/stop");
+    }
+
+    void Remove(const std::string& id)
+    {
+        Delete("/containers/" + id);
+    }
+
+    Response Get(const std::string& endpoint)
+    {
+        auto [code, content] = CurlRequest(Verb::GET, endpoint);
+        return {code, content.empty() ? nlohmann::json::object() : nlohmann::json::parse(content)};
+    }
+
+    Response Post(const std::string& endpoint, const nlohmann::json& body = {})
+    {
+        auto [code, content] = CurlRequest(Verb::POST, endpoint, body.dump());
+        return {code, content.empty() ? nlohmann::json::object() : nlohmann::json::parse(content)};
+    }
+
+    Response Delete(const std::string& endpoint, const nlohmann::json& body = {})
+    {
+        auto [code, content] = CurlRequest(Verb::DELETE, endpoint, body.dump());
+        return {code, content.empty() ? nlohmann::json::object() : nlohmann::json::parse(content)};
+    }
+
+    void SetLogOutput(std::ostream* os)
+    {
+        log_ = os;
+    }
+
+private:
+    enum class Verb { GET, POST, DELETE };
+
+    std::pair<int, std::string> CurlRequest(Verb verb, const std::string& endpoint, const std::string& body = "")
+    {
+        std::stringstream in, out;
+        out.str(body);
+
+        const char* verbStr = "GET";
+        struct curl_slist *headers = curl_slist_append(nullptr, "Content-Type: application/json");
+
+        curl_easy_reset(curl_);
+        curl_easy_setopt(curl_, CURLOPT_UNIX_SOCKET_PATH, "/var/run/docker.sock");
+        curl_easy_setopt(curl_, CURLOPT_URL, ("http:/v1.41" + endpoint).c_str());
+        curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers);
+
+        if (verb == Verb::POST) {
+            curl_easy_setopt(curl_, CURLOPT_POST, 1);
+            curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, body.length());
+            verbStr = "POST";
+        } else if (verb == Verb::DELETE) {
+            curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "DELETE");
+            curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, body.length());
+            verbStr = "DELETE";
+        }
+
+        curl_easy_setopt(curl_, CURLOPT_READFUNCTION, CurlReadCallback);
+        curl_easy_setopt(curl_, CURLOPT_READDATA, (void*)&out);
+        curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, CurlWriteCallback);
+        curl_easy_setopt(curl_, CURLOPT_WRITEDATA, (void*)&in);
+
+        int code = -1;
+        std::string response;
+        CURLcode ret = curl_easy_perform(curl_);
+        curl_slist_free_all(headers);
+
+        if (ret == CURLE_OK) {
+            curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &code);
+            response = in.str();
+            response.erase(response.find_last_not_of("\r\n") + 1);
+        } else {
+            response = "{\"curl_error\": " + std::to_string(ret) + "}";
+        }
+
+        if (log_) {
+            *log_ << verbStr << " " << endpoint << " = [" << code << "] " << response << std::endl;
+        }
+
+        return {code, std::move(response)};
+    }
+
+    static std::size_t CurlReadCallback(char *buffer, std::size_t size, std::size_t nitems, void *userdata)
+    {
+        std::stringstream& ss = *(static_cast<std::stringstream*>(userdata));
+        ss.get(buffer, size * nitems);
+        return ss.gcount();
+    }
+
+    static std::size_t CurlWriteCallback(const char *ptr, std::size_t size, std::size_t nmemb, void *userdata)
+    {
+        std::stringstream& ss = *(static_cast<std::stringstream*>(userdata));
+        ss.write(ptr, size * nmemb);
+        return size * nmemb;
+    }
+
+private:
+    CURL* curl_ = nullptr;
+    std::ostream* log_ = nullptr;
+};
+
+}
+
+#endif

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -23,7 +23,6 @@ int main(int argc, const char* argv[])
         }
     }
 
-
     if (use_container) {
         docker::Docker dock;
         auto id = dock.Launch(

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,73 @@
+#include <thread>
+
 #include <gtest/gtest.h>
+
+#include <influx/influx.hh>
+
+#include "docker.hh"
+
+using namespace std::literals::chrono_literals;
+
+namespace influx::test {
+    nlohmann::json docker_config;
+}
 
 int main(int argc, const char* argv[])
 {
     ::testing::InitGoogleTest(&argc, (char**) argv);
-    return RUN_ALL_TESTS();
+
+    bool use_container = false;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--use-container") == 0) {
+            use_container = true;
+        }
+    }
+
+
+    if (use_container) {
+        docker::Docker dock;
+        auto id = dock.Launch(
+            "influxdb:latest", 
+            {{docker::Protocol::TCP, 8086}},
+            {
+                {"DOCKER_INFLUXDB_INIT_MODE", "setup"},
+                {"DOCKER_INFLUXDB_INIT_USERNAME", "admin"},
+                {"DOCKER_INFLUXDB_INIT_PASSWORD", "influx-container-password"},
+                {"DOCKER_INFLUXDB_INIT_ORG", "test-org"},
+                {"DOCKER_INFLUXDB_INIT_BUCKET", "test-bucket"},
+                {"DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", "influx-container-token"}
+            }
+        );
+
+
+        int rc = -1;
+        try {
+            if (id) {
+                auto ip = dock.Get("/containers/" + id.value() + "/json").content["NetworkSettings"]["IPAddress"].get<std::string>();
+                
+                auto db = influx::Influx("http://" + ip + ":8086", "", "influx-container-token");
+                while(!db.Ready()) {
+                    std::this_thread::sleep_for(500ms);
+                }
+
+                influx::test::docker_config["host"] = "http://" + ip + ":8086";
+                influx::test::docker_config["org"] = db.OrgIdFromName("test-org");
+                influx::test::docker_config["token"] = "influx-container-token";
+            } else {
+                std::cerr << "Failed to launch Influx Container";
+                return EXIT_FAILURE;
+            }
+
+            rc = RUN_ALL_TESTS();
+        } catch (const std::exception& e) {
+            std::cerr << "FAILED: " << e.what() << std::endl;
+        }
+
+        dock.Stop(id.value());
+        dock.Remove(id.value());
+
+        return rc;
+    } else {
+        return RUN_ALL_TESTS();
+    } 
 }

--- a/tests/test_bucket.cc
+++ b/tests/test_bucket.cc
@@ -26,7 +26,7 @@ TEST_F(BucketTest, should_accept_measurements)
     EXPECT_EQ(bucket.BufferedMeasurementsCount(), 1);
 }
 
-TEST_F(BucketTest, should_allow_flusing_measurements)
+TEST_F(BucketTest, should_allow_flushing_measurements)
 {
     bucket << (influx::Measurement("m") << influx::Field{"field1", 42});
     bucket.Flush();


### PR DESCRIPTION
Add switch to unit test executable `--use-container` that will cause it to launch (and remove) an `influxdb` container. This requires the container to be pulled locally beforehand.
Also makes the CI job use this feature instead of setting up InfluxDB locally (which wasn't done on Windows)